### PR TITLE
Instructions review

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This lab is an exercise to check your knowledge on enabling GitHub Pages. It is 
 
 :warning: A grading script and a setup utility exist inside of the `.github/` directory. You do not need to use these workflows for any purpose and **altering their contents will affect the repository's ability to assess your lab and give feedback.**
 
-:information_source: This lab utilizes [GitHub Actions]( https://docs.github.com/en/actions) to grade the exercise, which means that it may take the grading workflow a few seconds and sometimes minutes to run.
+:warning: This lab utilizes [GitHub Actions](https://docs.github.com/en/actions), which is free for public repositories and self-hosted runners, but may incur charges on private repositories. See *[About billing for GitHub Actions]* to learn more.
+
+:information_source: The use of GitHub actions also means that it may take the grading workflow a few seconds and sometimes minutes to run.
 
 ## Instructions
 
@@ -45,6 +47,7 @@ Resources for working with labs and GitHub Actions in general:
 - [Creating a repository from a template]
 - [Viewing workflow run history]
 - [Running a workflow on GitHub]
+- [About billing for GitHub Actions]
 - [GitHub Actions]
 
 <!--
@@ -54,4 +57,5 @@ Links used throughout this README:
 [Creating a repository from a template]:                        https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template
 [Viewing workflow run history]:                                 https://docs.github.com/en/actions/managing-workflow-runs/viewing-workflow-run-history
 [Running a workflow on GitHub]:                                 https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github
+[About billing for GitHub Actions]:                             https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions
 [GitHub Actions]:                                               https://docs.github.com/en/actions

--- a/README.md
+++ b/README.md
@@ -1,40 +1,35 @@
 # Welcome to the lab on enabling GitHub Pages!
 
-- [About the codebase](#about-the-codebase)
-- [Lab instructions](#lab-instructions)
-- [Grading criteria](#grading-criteria)
-- [A note about usage of GitHub Actions](#a-note-about-usage-of-github-actions)
-- [References](#references)
+This lab is an exercise to check your knowledge on enabling GitHub Pages. It is automatically graded via a workflow once you have completed the instructions.
 
+**Quick links:**
+- [About this lab](#about-this-lab)
+- [Instructions](#instructions)
+- [Seeing your result](#seeing-your-result)
+- [Useful resources](#useful-resources)
+- [Troubleshooting](#troubleshooting)
 
-## About the codebase
-The codebase contains a starter GitHub pages site inside the `docs/` directory, but you can use any content you'd like as long as the conditions specified in the [grading criteria](#grading-criteria) are met. 
+## About this lab
 
-A grading script and a setup utility exist inside of the `.github/` directory. You do not need to use these workflows for any purpose and altering their contents will affect the repository's ability to assess your lab and give feedback.
+:warning: A grading script and a setup utility exist inside of the `.github/` directory. You do not need to use these workflows for any purpose and **altering their contents will affect the repository's ability to assess your lab and give feedback.**
 
-## Lab instructions
+:information_source: This lab utilizes [GitHub Actions]( https://docs.github.com/en/actions) to grade the exercise, which means that it may take the grading workflow a few seconds and sometimes minutes to run.
 
-1. Create your own copy of this repository.
-   - The easiest way to copy this repository is to click on **Use this template**. See *[Creating a repository from a template]* if you need assistance.
-2. Complete the [grading criteria](#grading-criteria) in your newly created repository.
-3. Your lab will be graded automatically when the grading criteria is met, this may take up to a minute.
-   - To see the results of your lab, click on the **Actions** tab, select the **Grading workflow**, and select the most recent workflow run. See *[Viewing workflow run history]* if you need assistance. 
-4. If you're having trouble getting started, run the troubleshooter: click on the **Actions** tab, select the **Grading workflow**, click on **Run workflow**, select the appropriate branch (usually `main`), and click on the **Run workflow** button. See *[Running a workflow on GitHub]* if you need asssistance.
+## Instructions
 
-## Grading criteria
+1. Create your own copy of this repository by using the [Use this template](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template) option. Make sure you set your repository visibility to **Public** when asked.
+2. In your newly created repository, enable GitHub Pages with the `main` branch and the `docs/` directory as the source for the GitHub Pages site.
 
-To successfully complete this lab, the following conditions must be met:
-- Your repository must be public
-- GitHub Pages must be enabled
-- The GitHub Pages site must use the `main` branch as the source
-- The GitHub Pages site must use the `docs/` directory as the source
+## Seeing your result
 
-## A note about usage of GitHub Actions
-This lab utilizes GitHub Actions, which is free for public repositories and self-hosted runners, but may incur charges on private repositories. See *[About billing for GitHub Actions]* to learn more.
+Your lab is graded automatically once you have completed the instructions. To see the result of your lab, click the **Actions** tab, select the **Grading workflow**, and select the most recent workflow run. The status of the workflow indicates if you have passed or failed the lab.
 
-The use of GitHub actions also means that it may take the grading workflows a few seconds and sometimes minutes to run. To learn more about how GitHub Actions runs and evaluates your code, please see the landing page for *[GitHub Actions]* documentation.
+If the workflow failed, scroll down to the **Annotations** section to check what went wrong.
 
-## References
+See *[Viewing workflow run history]* if you need assistance.
+
+## Useful resources
+
 Use these to help you!
 
 Resources specific to this lab:
@@ -44,15 +39,19 @@ Resources for working with labs and GitHub Actions in general:
 - [Creating a repository from a template]
 - [Viewing workflow run history]
 - [Running a workflow on GitHub]
-- [About billing for GitHub Actions]
 - [GitHub Actions]
 
-<!-- 
-Links used throughout this README: 
+<!--
+Links used throughout this README:
 -->
 [Configuring a publishing source for your GitHub Pages site]:   https://docs.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
 [Creating a repository from a template]:                        https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template
 [Viewing workflow run history]:                                 https://docs.github.com/en/actions/managing-workflow-runs/viewing-workflow-run-history
 [Running a workflow on GitHub]:                                 https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github
-[About billing for GitHub Actions]:                             https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions
 [GitHub Actions]:                                               https://docs.github.com/en/actions
+
+## Troubleshooting
+
+ If the grading workflow does not automatically run after you complete the instructions, run the troubleshooter: in the **Actions** tab select the **Grading workflow**, click **Run workflow**, select the appropriate branch (usually `main`), and click the **Run workflow** button.
+
+ See *[Running a workflow on GitHub]* if you need assistance.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This lab is an exercise to check your knowledge on enabling GitHub Pages. It is 
 
 ## Instructions
 
-1. Create your own copy of this repository by using the [Use this template](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template) option. Make sure you set your repository visibility to **Public** when asked.
+1. Create your own copy of this repository by using the [Use this template](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template) button. Make sure you set your repository visibility to **Public** when asked.
 2. In your newly created repository, enable GitHub Pages with the `main` branch and the `docs/` directory as the source for the GitHub Pages site.
 
 ## Seeing your result

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This lab is an exercise to check your knowledge on enabling GitHub Pages. It is 
 - [About this lab](#about-this-lab)
 - [Instructions](#instructions)
 - [Seeing your result](#seeing-your-result)
-- [Useful resources](#useful-resources)
 - [Troubleshooting](#troubleshooting)
+- [Useful resources](#useful-resources)
 
 ## About this lab
 
@@ -27,6 +27,12 @@ Your lab is graded automatically once you have completed the instructions. To se
 If the workflow failed, scroll down to the **Annotations** section to check what went wrong.
 
 See *[Viewing workflow run history]* if you need assistance.
+
+## Troubleshooting
+
+ If the grading workflow does not automatically run after you complete the instructions, run the troubleshooter: in the **Actions** tab select the **Grading workflow**, click **Run workflow**, select the appropriate branch (usually `main`), and click the **Run workflow** button.
+
+ See *[Running a workflow on GitHub]* if you need assistance.
 
 ## Useful resources
 
@@ -49,9 +55,3 @@ Links used throughout this README:
 [Viewing workflow run history]:                                 https://docs.github.com/en/actions/managing-workflow-runs/viewing-workflow-run-history
 [Running a workflow on GitHub]:                                 https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github
 [GitHub Actions]:                                               https://docs.github.com/en/actions
-
-## Troubleshooting
-
- If the grading workflow does not automatically run after you complete the instructions, run the troubleshooter: in the **Actions** tab select the **Grading workflow**, click **Run workflow**, select the appropriate branch (usually `main`), and click the **Run workflow** button.
-
- See *[Running a workflow on GitHub]* if you need assistance.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This lab is an exercise to check your knowledge on enabling GitHub Pages. It is 
 
 :warning: This lab utilizes [GitHub Actions](https://docs.github.com/en/actions), which is free for public repositories and self-hosted runners, but may incur charges on private repositories. See *[About billing for GitHub Actions]* to learn more.
 
-:information_source: The use of GitHub actions also means that it may take the grading workflow a few seconds and sometimes minutes to run.
+:information_source: The use of GitHub Actions also means that it may take the grading workflow a few seconds and sometimes minutes to run.
 
 ## Instructions
 


### PR DESCRIPTION
Hi @hectorsector, here is my first lab instructions review! 

What I did is:
- Deleted non-essential information such as private repo billing info (since the repo has to be public).
- Made the sections' intent clearer and redistributed information accordingly. For example, the former "Lab instructions" section contained instructions, information on how to see your result and information on troubleshooting the grading workflow. I split the info it contained into 3 different sections: "Instructions", "Seeing your result" and "Troubleshooting".
- Moved the "Grading criteria" section into the "Instructions" one.

I hesitated putting screenshots in some sections but remembered you wanted to keep the instructions light with just references to the docs. I am on the fence on this, I think screenshots would be helpful to the learner, especially to help them read their workflow run log, rather than sending them to the docs, what do you think? For now I just left things without screenshots.